### PR TITLE
Easier working with config files

### DIFF
--- a/src/Language/LanguagePrototype.php
+++ b/src/Language/LanguagePrototype.php
@@ -10,7 +10,21 @@ use Exception;
  */
 abstract class LanguagePrototype
 {
+    /**
+     * Language for the API
+     * @var string
+     */
+    private $lang;
 
+    /**
+     * LanguagePrototype constructor.
+     * @param string $lang Lang of Api
+     */
+    public function __construct(string $lang = '')
+    {
+
+        $this->lang = ($lang!== '')?$lang:strtolower((new \ReflectionClass($this))->getShortName());
+    }
     /**
      * Convert server to url string.
      *
@@ -20,7 +34,7 @@ abstract class LanguagePrototype
      */
     public function __toString(): string
     {
-        return strtolower((new \ReflectionClass($this))->getShortName());
+        return $this->lang;
     }
 
 }

--- a/src/Server/ASIA.php
+++ b/src/Server/ASIA.php
@@ -3,7 +3,7 @@
 namespace Wargaming\Server;
 
 /**
- * Class RU
+ * Class ASIA
  * @package Wargaming\Server
  */
 final class ASIA extends ServerPrototype
@@ -11,5 +11,5 @@ final class ASIA extends ServerPrototype
     /**
      * Api Server URL
      */
-    const URL = 'api.worldoftanks.asia';
+    protected $URL = 'api.worldoftanks.asia';
 }

--- a/src/Server/Custom.php
+++ b/src/Server/Custom.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Wargaming\Server;
+
+/**
+ * Class RU
+ * @package Wargaming\Server
+ */
+final class Custom extends ServerPrototype
+{
+
+}

--- a/src/Server/EU.php
+++ b/src/Server/EU.php
@@ -11,5 +11,5 @@ final class EU extends ServerPrototype
     /**
      * Api Server URL
      */
-    const URL = 'api.worldoftanks.eu';
+    protected $URL = 'api.worldoftanks.eu';
 }

--- a/src/Server/KR.php
+++ b/src/Server/KR.php
@@ -3,7 +3,7 @@
 namespace Wargaming\Server;
 
 /**
- * Class RU
+ * Class KR
  * @package Wargaming\Server
  */
 final class KR extends ServerPrototype
@@ -11,5 +11,5 @@ final class KR extends ServerPrototype
     /**
      * Api Server URL
      */
-    const URL = 'api.worldoftanks.kr';
+    protected $URL = 'api.worldoftanks.kr';
 }

--- a/src/Server/NA.php
+++ b/src/Server/NA.php
@@ -11,5 +11,5 @@ final class NA extends ServerPrototype
     /**
      * Api Server URL
      */
-    const URL = 'api.worldoftanks.com';
+    protected $URL = 'api.worldoftanks.com';
 }

--- a/src/Server/RU.php
+++ b/src/Server/RU.php
@@ -11,5 +11,5 @@ final class RU extends ServerPrototype
     /**
      * Api Server URL
      */
-    const URL = 'api.worldoftanks.ru';
+    protected $URL = 'api.worldoftanks.ru';
 }

--- a/src/Server/ServerPrototype.php
+++ b/src/Server/ServerPrototype.php
@@ -13,8 +13,10 @@ abstract class ServerPrototype
 
     /**
      * Api Server URL
+     *
+     * @var string
      */
-    const URL = '';
+    protected $URL = '';
 
     /**
      * Api key (application id)
@@ -27,18 +29,24 @@ abstract class ServerPrototype
      * ServerPrototype constructor.
      *
      * @param   string  $application_id  Application ID registered in this server.
+     * @param   string  $url  API-Server URL, can be defined by using explicit classes
      *
      * @throws Exception
      */
-    public function __construct(string $application_id = '')
+    public function __construct(string $application_id = '', string $url = '')
     {
+
+        //set new url if provided
+        if($url !== ''){
+            $this->URL = $url;
+        }
 
         // If there was an api key provided, use it.
         if ($application_id !== '') {
             $this->application_id = $application_id;
         }
 
-        if (!is_string($this::URL) || $this::URL === '') {
+        if (!is_string($this->URL) || $this->URL === '') {
             throw new Exception('Server object is missing URL constant.');
         }
     }
@@ -66,7 +74,7 @@ abstract class ServerPrototype
      */
     public function __toString(): string
     {
-        return $this::URL;
+        return $this->URL;
     }
 
     /**


### PR DESCRIPTION
in Version 1.3 you could store the language string (en, de, ru, pl, ...) and the api-server string  (api.worldoftanks.ru, ...)  in a config file. With the current version you have to use Classes. In one of my projects it is not easy to store a class in a config file.

This patch allows the use of strings as optional parameters. 